### PR TITLE
Disable noarch in docbook-xsl: no need to set XML_CATALOG_FILES on win-64

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,20 +4,6 @@ echo v0.1.0-dev.3-0-g984df1b-experimental/jiffies ^
     > "%SRC_DIR%\TVIPS-TOOLS-VERSION-FILE"
 del "%SRC_DIR%\VERSION"
 
-
-:: This should not be necessary.
-echo M1
-dir %CONDA_PREFIX%
-echo M2
-dir %CONDA_PREFIX%\etc
-echo M3
-dir %CONDA_PREFIX%\etc\xml
-echo M4
-set | findstr catalog
-echo M5
-:: set XML_CATALOG_FILES=%CONDA_PREFIX%\share\docbook-xsl\catalog.xml
-echo M6
-
 cmake -G "MinGW Makefiles" %CMAKE_ARGS%                               ^
     -DCMAKE_C_FLAGS:STRING="%CFLAGS% -D_POSIX_C_SOURCE=200809L -Wall" ^
     -DCMAKE_COLOR_MAKEFILE:BOOL=OFF                                   ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,7 +13,10 @@ dir %CONDA_PREFIX%\etc
 echo M3
 dir %CONDA_PREFIX%\etc\xml
 echo M4
-set XML_CATALOG_FILES=%CONDA_PREFIX%\share\docbook-xsl\catalog.xml
+set | findstr catalog
+echo M5
+:: set XML_CATALOG_FILES=%CONDA_PREFIX%\share\docbook-xsl\catalog.xml
+echo M6
 
 cmake -G "MinGW Makefiles" %CMAKE_ARGS%                               ^
     -DCMAKE_C_FLAGS:STRING="%CFLAGS% -D_POSIX_C_SOURCE=200809L -Wall" ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
 build:
   ignore_run_exports_from:
     - {{ compiler('cxx') }}
-  number: 2
+  number: 3
   script_env:
     - USER      # [unix]
     - USERNAME  # [win]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
